### PR TITLE
Update soundboard responsiveness + other small things

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -78,7 +78,7 @@
     <link rel="stylesheet" href="/css/index_style.css">
     <link href="https://fonts.googleapis.com/css?family=Courgette" rel="stylesheet" type="text/css">
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.0.3/howler.core.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.7.3/socket.io.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.2/socket.io.slim.js"></script>
 	<script src="/js/sounds.js"></script>
     <script src="/js/count.js" async></script>
     <script src="/js/googleanalytics.js" async></script>

--- a/src/pages/soundboard.html
+++ b/src/pages/soundboard.html
@@ -32,72 +32,72 @@
 	    <a href="/" id="backlink-top" class="backlink">Back</a>
 		<!--Sound buttons-->
 		<div id="season1" class="titles">Season 1:</div>
-		<button class="buttons s1" id="explosion">Explosion!</button>
-		<button class="buttons s1" id="plosion">'plosion!</button>
-		<button class="buttons s1" id="sion">'sion!</button>
-		<button class="buttons s1" id="n">'n!</button>
-		<button class="buttons s1" id="eugh1">Eugh #1</button>
-		<button class="buttons s1" id="eugh2">Eugh #2</button>
-		<button class="buttons s1" id="eugh3">Eugh #3</button>
-		<button class="buttons s1" id="eugh4">Eugh #4</button>
-		<button class="buttons s1" id="yamero">やめろ!!</button>
-		<button class="buttons s1" id="pull">Eyepatch-Pull</button>
-		<button class="buttons s1" id="itai">痛い!</button>
-		<button class="buttons s1" id="name">My Name is..</button>
-		<button class="buttons s1" id="oi">Oi</button>
-		<button class="buttons s1" id="magic-item">Magic Item</button>
-		<button class="buttons s1" id="parents">Parents</button>
-		<button class="buttons s1" id="hyoizaburo">Hyoizaburo!</button>
-        <button class="buttons s1" id="star">Star entry</button>
+		<div class="buttons-wrap">
+			<button id="explosion">Explosion!</button>
+			<button id="plosion">'plosion!</button>
+			<button id="sion">'sion!</button>
+			<button id="n">'n!</button>
+			<button id="eugh1">Eugh #1</button>
+			<button id="eugh2">Eugh #2</button>
+			<button id="eugh3">Eugh #3</button>
+			<button id="eugh4">Eugh #4</button>
+			<button id="yamero">やめろ!!</button>
+			<button id="pull">Eyepatch-Pull</button>
+			<button id="itai">痛い!</button>
+			<button id="name">My Name is..</button>
+			<button id="oi">Oi</button>
+			<button id="magic-item">Magic Item</button>
+			<button id="parents">Parents</button>
+			<button id="hyoizaburo">Hyoizaburo!</button>
+			<button id="star">Star entry</button>
+		</div>
 		<br>
 		<br>
 		<div id="season2" class="titles">Season 2:</div>
-		<button class="buttons s2" id="igiari">異議あり!!</button>
-		<button class="buttons s2" id="hmph">Hmph</button>
-        <button class="buttons s2" id="zuryah">Zuryah!!</button>
-        <button class="buttons s2" id="whatsthis">What's this?!</button>
-        <button class="buttons s2" id="who">Who..?</button>
-        <button class="buttons s2" id="yes">Yes</button>
-        <button class="buttons s2" id="yoroshii">よろしい</button>
-        <button class="buttons s2" id="tropes">Tropes</button>
-        <button class="buttons s2" id="truepower">True Power</button>
-        <button class="buttons s2" id="waah">Waah!</button>
-        <button class="buttons s2" id="wellthanks">Well, thanks</button>
-        <button class="buttons s2" id="oh">Oh</button>
-        <button class="buttons s2" id="shouganai">しょうがない</button>
-        <button class="buttons s2" id="sigh">Sigh</button>
-        <button class="buttons s2" id="splat">*splat*</button>
-        <button class="buttons s2" id="itscold">It's cold</button>
-        <button class="buttons s2" id="ladiesfirst">Ladies first</button>
-        <button class="buttons s2" id="mywin">My Win!</button>
-        <button class="buttons s2" id="nani">Nani?!</button>
-        <button class="buttons s2" id="dontwanna">Don't wanna</button>
-        <button class="buttons s2" id="doushimashou">どうしましょう</button>
-        <button class="buttons s2" id="friends">Friends</button>
-        <button class="buttons s2" id="hau">Hau</button>
-        <button class="buttons s2" id="isee">I see</button>
-        <button class="buttons s2" id="bighug">Big Hug</button>
-        <button class="buttons s2" id="chomusuke">Chomusuke</button>
-        <button class="buttons s2" id="comeatme">Come at me!</button>
-        <button class="buttons s2" id="dododo">Dododo</button>
-        <button class="buttons s2" id="are">Are?</button>
-        <button class="buttons s2" id="aughh">Aughh</button>
-        <button class="buttons s2" id="chomusukefaint">Chomu Faint</button>
-        <button class="buttons s2" id="ripchomusuke">RIP Chomu</button>
-        <button class="buttons s2" id="explosion2">Explosion! 2</button>
-        <button class="buttons s2" id="losion">'losion!</button>
-        <button class="buttons s2" id="sion2">'sion! 2</button>
-        <button class="buttons s2" id="n2">'n! 2</button>
-        <button class="buttons s2" id="hua">Hua</button>
-        <button class="buttons s2" id="thinking">Thinking</button>
-        <button class="buttons s2" id="lalala">♬Explosions♬</button>
-		<button class="buttons s2" id="chunchunmaru">Chunchunmaru</button>
+		<div class="buttons-wrap">
+			<button id="igiari">異議あり!!</button>
+			<button id="hmph">Hmph</button>
+			<button id="zuryah">Zuryah!!</button>
+			<button id="whatsthis">What's this?!</button>
+			<button id="who">Who..?</button>
+			<button id="yes">Yes</button>
+			<button id="yoroshii">よろしい</button>
+			<button id="tropes">Tropes</button>
+			<button id="truepower">True Power</button>
+			<button id="waah">Waah!</button>
+			<button id="wellthanks">Well, thanks</button>
+			<button id="oh">Oh</button>
+			<button id="shouganai">しょうがない</button>
+			<button id="sigh">Sigh</button>
+			<button id="splat">*splat*</button>
+			<button id="itscold">It's cold</button>
+			<button id="ladiesfirst">Ladies first</button>
+			<button id="mywin">My Win!</button>
+			<button id="nani">Nani?!</button>
+			<button id="dontwanna">Don't wanna</button>
+			<button id="doushimashou">どうしましょう</button>
+			<button id="friends">Friends</button>
+			<button id="hau">Hau</button>
+			<button id="isee">I see</button>
+			<button id="bighug">Big Hug</button>
+			<button id="chomusuke">Chomusuke</button>
+			<button id="comeatme">Come at me!</button>
+			<button id="dododo">Dododo</button>
+			<button id="are">Are?</button>
+			<button id="aughh">Aughh</button>
+			<button id="chomusukefaint">Chomu Faint</button>
+			<button id="ripchomusuke">RIP Chomu</button>
+			<button id="explosion2">Explosion! 2</button>
+			<button id="losion">'losion!</button>
+			<button id="sion2">'sion! 2</button>
+			<button id="n2">'n! 2</button>
+			<button id="hua">Hua</button>
+			<button id="thinking">Thinking</button>
+			<button id="lalala">♬Explosions♬</button>
+			<button id="chunchunmaru">Chunchunmaru</button>
+		</div>
 		<a href="/" id="backlink-bottom" class="backlink">Back</a>
 	</div>
-    <div id="mobileContainer">
-        <h1>Sorry, Soundboard not supported on mobile!</h1>
-        <a href="/" id="backlink-mobile" class="backlink">Back</a>
-    </div>
 	
 	<!--Sidebar-->
 	<div id="navbar-slide" class="navbarPc">

--- a/src/pages/statistics.html
+++ b/src/pages/statistics.html
@@ -74,7 +74,7 @@
     <!--Ressource loading-->
     <link rel="stylesheet" href="/css/statistics_style.css">
     <link href="https://fonts.googleapis.com/css?family=Courgette" rel="stylesheet" type="text/css">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.7.3/socket.io.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.2/socket.io.slim.js"></script>
 	<script src="/js/statistics.js" async></script
     <script src="/js/googleanalytics.js" async></script>
 </body>

--- a/src/resources/css/soundboard_style.css
+++ b/src/resources/css/soundboard_style.css
@@ -1,52 +1,51 @@
 @import url("./style_template.css");
 
+body {
+	padding-bottom: 75px;
+}
+
 div#container {
-    width: 1175px;
-    margin-left: auto;
-    margin-right: auto;
-    background: rgba(0, 0, 0, 0.5);
-    padding: 16px;
-    box-sizing: border-box;
-    border-radius: 20px;
+	width: 90%;
+	margin: 0 auto;
+	background-color: rgba(0, 0, 0, 0.5);
+	padding: 16px;
+	box-sizing: border-box;
+	border-radius: 20px;
+	text-align: center;
 }
 
-div#mobileContainer {
-   width: 250px;
-    margin-top: 100px;
-    margin-left: auto;
-    margin-right: auto;
-    background: rgba(0, 0, 0, 1);
-    color: white;
-    padding: 16px;
-    box-sizing: border-box;
-    border-radius: 20px;
-    display: none;
+.buttons-wrap {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	margin-top: 10px;
 }
 
-button.buttons {
+.buttons-wrap button {
 	margin-top: 10px;
 	margin-left: 5px;
-    font-size: 35px;
-    background: #dd0000;
-    color: #ff8080;
-    border-radius: 20px;
-    width: 23%;
+	font-size: 35px;
+	background: #dd0000;
+	color: #ff8080;
+	border-radius: 20px;
+	width: 24%;
 	box-shadow: -3px 1px 40px 14px rgba(51,38,51,0.6);
 }
 
-button.buttons:focus {
+.buttons-wrap button:focus {
 	outline: 0;
 }
 
-button.buttons:hover {
-    background: #ff3338;
+.buttons-wrap button:hover {
+	background: #ff3338;
 }
 
 .titles {
-	margin-left: 300px;
+	margin: 0 auto;
 	font-size: 35px;
 	text-align: center;
-	background: #dd0000;
+	background-color: #dd0000;
 	color: #ff8080;
 	border-radius: 15px;
 	width: 50%;
@@ -54,31 +53,32 @@ button.buttons:hover {
 }
 
 a.backlink {
-    color: #dd0000;
+	color: #dd0000;
+	display: block;
+	text-align: left;
+	margin-bottom: 10px;
 }
 
 a#backlink-bottom {
-	margin-left: 1100px;
+	text-align: right;
+	margin: 10px 0 0;
 }
 
-@media only screen and (max-width: 599px) {
-    /* Portrait mode */  
-    div#container {
-		display: none;
-    }
-    
-    div#mobileContainer {
-        display: block;
-    }
+@media only screen and (max-width: 1150px) {
+	.buttons-wrap button {
+		width: 32%;
+	}
 }
-@media only screen and (max-height: 599px) {
-    /* Landscape mode */
-    div#container {
-		display: none;
-    }
 
-    div#mobileContainer {
-        margin-top: 0px;
-        display: block;
-    }
+@media only screen and (max-width: 950px) {
+	.buttons-wrap button {
+		width: 49%;
+	}
+}
+
+@media only screen and (max-width: 650px) {
+	.buttons-wrap button,
+	.titles {
+		width: 100%;
+	}
 }

--- a/src/resources/css/soundboard_style.css
+++ b/src/resources/css/soundboard_style.css
@@ -5,13 +5,20 @@ body {
 }
 
 div#container {
-	width: 90%;
+	width: 1175px;
 	margin: 0 auto;
 	background-color: rgba(0, 0, 0, 0.5);
 	padding: 16px;
 	box-sizing: border-box;
 	border-radius: 20px;
-	text-align: center;
+}
+
+div#container::after {
+	content: ".";
+	display: block;
+	height: 0;
+	clear: both;
+	visibility: hidden;
 }
 
 .buttons-wrap {
@@ -54,17 +61,21 @@ div#container {
 
 a.backlink {
 	color: #dd0000;
-	display: block;
+	display: inline-block;
 	text-align: left;
 	margin-bottom: 10px;
 }
 
 a#backlink-bottom {
-	text-align: right;
+	float: right;
 	margin: 10px 0 0;
 }
 
 @media only screen and (max-width: 1150px) {
+	div#container {
+		width: 90%;
+	}
+
 	.buttons-wrap button {
 		width: 32%;
 	}

--- a/src/resources/css/style_template.css
+++ b/src/resources/css/style_template.css
@@ -10,10 +10,11 @@ body {
     background: url(/images/bg.jpg) no-repeat center center fixed;
     background-size: cover;
     vertical-align: middle;
+	position: relative;
 }
 
 footer {
-    position: fixed;
+    position: absolute;
     bottom: 0;
     left: 0;
     width: 18%;


### PR DESCRIPTION
- Wrap the buttons in a nice lil div, for flexbox/alignment/responsive reasons
- Remove the classes from all buttons since they were no longer necessary
- Removed the .mobileContainer div stating that the soundboard isn't support on mobile
- Updated the #container selector to use a width of 90%, also make the text centered
- Make the soundboard actually responsive, with buttons-per-rows displayed depending on device width
- No more fixed scrolling footer
- Updated socket.io CDN links to v2.0.2, as per request